### PR TITLE
Add AetherAI demo Flask app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# STN
-hi!
+# AetherAI Demo
+
+This repository contains a simple Flask web application demonstrating an AI assistant called **AetherAI**. The application includes a basic chat interface and a placeholder subscription check.
+
+## Running the app
+
+1. Install dependencies:
+   ```bash
+   pip install flask
+   ```
+2. Start the server:
+   ```bash
+   python app.py
+   ```
+3. Open `http://localhost:5000` in your browser.
+
+A single demo user `demo@example.com` is subscribed by default. Integrate your own subscription and AI logic as needed.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,28 @@
+from flask import Flask, render_template, request, jsonify
+
+app = Flask(__name__)
+
+# Placeholder for user subscription check
+SUBSCRIBED_USERS = {"demo@example.com"}
+
+# Basic placeholder AI response
+def ai_response(message):
+    # This is a stub; integrate real model here
+    return f"AetherAI echo: {message}"
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/chat', methods=['POST'])
+def chat():
+    data = request.get_json(force=True)
+    user = data.get('user')
+    message = data.get('message')
+    if user not in SUBSCRIBED_USERS:
+        return jsonify({'error': 'User not subscribed'}), 403
+    response = ai_response(message)
+    return jsonify({'response': response})
+
+if __name__ == '__main__':
+    app.run(debug=True, host='0.0.0.0')

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,18 @@
+body {
+    font-family: Arial, sans-serif;
+    max-width: 600px;
+    margin: 2em auto;
+    background-color: #f9f9f9;
+    padding: 1em;
+    border-radius: 4px;
+}
+#chat-box {
+    border: 1px solid #ccc;
+    padding: 10px;
+    height: 300px;
+    overflow-y: scroll;
+    background: #fff;
+}
+.user { color: blue; margin: 5px 0; }
+.bot { color: green; margin: 5px 0; }
+.error { color: red; }

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>AetherAI Chat</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <h1>AetherAI</h1>
+    <div id="chat-box"></div>
+    <input type="text" id="user-input" placeholder="Type your message" />
+    <button onclick="sendMessage()">Send</button>
+    <script>
+        async function sendMessage() {
+            const inputEl = document.getElementById('user-input');
+            const message = inputEl.value;
+            inputEl.value = '';
+            const res = await fetch('/chat', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({user: 'demo@example.com', message})
+            });
+            const data = await res.json();
+            const box = document.getElementById('chat-box');
+            if (data.error) {
+                box.innerHTML += '<div class="error">'+data.error+'</div>';
+            } else {
+                box.innerHTML += '<div class="user">'+message+'</div>';
+                box.innerHTML += '<div class="bot">'+data.response+'</div>';
+            }
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build a minimal Flask app for AetherAI
- add simple chat interface and placeholder AI logic
- provide basic style and README instructions

## Testing
- `python -m py_compile app.py`
- *(fails: `ModuleNotFoundError: No module named 'flask'` when running server)*


------
https://chatgpt.com/codex/tasks/task_e_683f0fe754f883318c3148d61ba161fd