### PR TITLE
Add VTMB translation patch sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,17 @@ This repository contains a simple Flask web application demonstrating an AI assi
 3. Open `http://localhost:5000` in your browser.
 
 A single demo user `demo@example.com` is subscribed by default. Integrate your own subscription and AI logic as needed.
+
+## Creating a VTMB Turkish Patch
+
+The `scripts/vtmb_tr_patch.py` script applies Turkish translations to a text
+file from the VTMB Unofficial Patch. Provide a CSV file with English and Turkish
+phrases and run:
+
+```bash
+python scripts/vtmb_tr_patch.py path/to/original.txt scripts/sample_translations.csv patched.txt
+```
+
+The example `scripts/sample_translations.csv` demonstrates the CSV format. The
+script replaces any matching English lines in the original file with their
+Turkish equivalents and writes the result to `patched.txt`.

--- a/scripts/sample_translations.csv
+++ b/scripts/sample_translations.csv
@@ -1,0 +1,2 @@
+Hello, kindred!;Merhaba, kandan kardesim!
+I need your help.;Yardimina ihtiyacim var.

--- a/scripts/vtmb_tr_patch.py
+++ b/scripts/vtmb_tr_patch.py
@@ -1,0 +1,39 @@
+import csv
+from pathlib import Path
+import argparse
+
+
+def load_translations(csv_path):
+    translations = {}
+    with open(csv_path, newline='', encoding='utf-8') as f:
+        reader = csv.reader(f, delimiter=';')
+        for row in reader:
+            if len(row) >= 2:
+                english, turkish = row[0].strip(), row[1].strip()
+                translations[english] = turkish
+    return translations
+
+
+def patch_file(original_path, translations, output_path):
+    output_lines = []
+    with open(original_path, encoding='utf-8') as f:
+        for line in f:
+            stripped = line.strip()
+            # Replace line if translation exists
+            translated = translations.get(stripped)
+            output_lines.append((translated + '\n') if translated else line)
+
+    with open(output_path, 'w', encoding='utf-8') as f:
+        for line in output_lines:
+            f.write(line)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Apply Turkish translations to VTMB patch file")
+    parser.add_argument("original", help="Path to the original text file from the patch")
+    parser.add_argument("translations", help="CSV file containing English and Turkish text pairs")
+    parser.add_argument("output", help="Path for the patched text file")
+    args = parser.parse_args()
+
+    translations = load_translations(args.translations)
+    patch_file(args.original, translations, args.output)


### PR DESCRIPTION
## Summary
- add a Python script that applies Turkish translations to a VTMB text file
- include example CSV translations
- document how to run the patch script in the README

## Testing
- `python -m py_compile scripts/vtmb_tr_patch.py`
- `python scripts/vtmb_tr_patch.py sample.txt scripts/sample_translations.csv patched.txt`

------
https://chatgpt.com/codex/tasks/task_e_68472a9f4b70833196c1ce563ed0a145