### PR TITLE
Add Tycron note-taking app

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,20 @@ This repository contains a simple Flask web application demonstrating an AI assi
 3. Open `http://localhost:5000` in your browser.
 
 A single demo user `demo@example.com` is subscribed by default. Integrate your own subscription and AI logic as needed.
+
+---
+
+## Tycron Note Taker
+
+A minimal GoodNotes-like application built with Tkinter. You can draw on a canvas, choose brush colors, and save your notes as PNG images.
+
+### Run Tycron
+
+1. Install dependencies:
+   ```bash
+   pip install pillow
+   ```
+2. Launch the app:
+   ```bash
+   python tycron.py
+   ```

--- a/tycron.py
+++ b/tycron.py
@@ -1,0 +1,85 @@
+import tkinter as tk
+from tkinter import filedialog, colorchooser
+from PIL import Image, ImageDraw
+
+class Tycron(tk.Tk):
+    def __init__(self):
+        super().__init__()
+        self.title("Tycron")
+        self.geometry("800x600")
+        self.canvas = tk.Canvas(self, bg='white', width=800, height=550)
+        self.canvas.pack(fill=tk.BOTH, expand=True)
+        self.bind_events()
+        self.setup_menu()
+        self.image = Image.new('RGB', (800, 550), 'white')
+        self.draw = ImageDraw.Draw(self.image)
+        self.last_x, self.last_y = None, None
+        self.color = 'black'
+        self.brush_size = 3
+
+    def bind_events(self):
+        self.canvas.bind('<ButtonPress-1>', self.on_press)
+        self.canvas.bind('<B1-Motion>', self.on_drag)
+        self.canvas.bind('<ButtonRelease-1>', self.reset)
+
+    def setup_menu(self):
+        menubar = tk.Menu(self)
+        filemenu = tk.Menu(menubar, tearoff=0)
+        filemenu.add_command(label='New', command=self.new_page)
+        filemenu.add_command(label='Open', command=self.open_image)
+        filemenu.add_command(label='Save', command=self.save_image)
+        filemenu.add_separator()
+        filemenu.add_command(label='Exit', command=self.quit)
+        menubar.add_cascade(label='File', menu=filemenu)
+
+        toolsmenu = tk.Menu(menubar, tearoff=0)
+        toolsmenu.add_command(label='Brush Color', command=self.choose_color)
+        menubar.add_cascade(label='Tools', menu=toolsmenu)
+
+        self.config(menu=menubar)
+
+    def new_page(self):
+        self.canvas.delete('all')
+        self.image = Image.new('RGB', (800, 550), 'white')
+        self.draw = ImageDraw.Draw(self.image)
+
+    def open_image(self):
+        filepath = filedialog.askopenfilename(filetypes=[('PNG Images', '*.png')])
+        if not filepath:
+            return
+        img = tk.PhotoImage(file=filepath)
+        self.canvas.delete('all')
+        self.canvas.create_image(0, 0, anchor='nw', image=img)
+        self.canvas.image = img
+        self.image = Image.open(filepath)
+        self.draw = ImageDraw.Draw(self.image)
+
+    def save_image(self):
+        filepath = filedialog.asksaveasfilename(defaultextension='.png',
+                                                filetypes=[('PNG Images', '*.png')])
+        if filepath:
+            self.image.save(filepath)
+
+    def choose_color(self):
+        color = colorchooser.askcolor(initialcolor=self.color)
+        if color[1]:
+            self.color = color[1]
+
+    def on_press(self, event):
+        self.last_x, self.last_y = event.x, event.y
+
+    def on_drag(self, event):
+        if self.last_x is not None and self.last_y is not None:
+            self.canvas.create_line(self.last_x, self.last_y, event.x, event.y,
+                                    fill=self.color, width=self.brush_size,
+                                    capstyle=tk.ROUND, smooth=True)
+            self.draw.line((self.last_x, self.last_y, event.x, event.y),
+                           fill=self.color, width=self.brush_size)
+        self.last_x, self.last_y = event.x, event.y
+
+    def reset(self, event):
+        self.last_x, self.last_y = None, None
+
+if __name__ == '__main__':
+    app = Tycron()
+    app.mainloop()


### PR DESCRIPTION
## Summary
- add `tycron.py`, a minimal Tkinter-based note-taking app
- document Tycron usage in README

## Testing
- `python tycron.py` *(fails: ModuleNotFoundError: No module named 'PIL')*
- `pip install pillow` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684a9d63b6288331bb1b4b18f4de7b9a