### PR TITLE
Add simple Onedio-style blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# AetherAI Demo
+# Blog Demo
 
-This repository contains a simple Flask web application demonstrating an AI assistant called **AetherAI**. The application includes a basic chat interface and a placeholder subscription check.
+This repository contains a simple Flask web application that mimics an **Onedio** style blog.
+It showcases trending posts and standard articles with a minimal layout.
 
 ## Running the app
 
@@ -14,4 +15,5 @@ This repository contains a simple Flask web application demonstrating an AI assi
    ```
 3. Open `http://localhost:5000` in your browser.
 
-A single demo user `demo@example.com` is subscribed by default. Integrate your own subscription and AI logic as needed.
+Sample posts are defined in `app.py`. Modify them or integrate a real database
+as needed.

--- a/app.py
+++ b/app.py
@@ -1,18 +1,44 @@
-from flask import Flask, render_template, request, jsonify
+from flask import Flask, render_template, request, jsonify, abort
 
 app = Flask(__name__)
 
-# Placeholder for user subscription check
+# Placeholder for user subscription check (for chat feature)
 SUBSCRIBED_USERS = {"demo@example.com"}
 
-# Basic placeholder AI response
+# Sample blog posts (would normally come from a database)
+POSTS = [
+    {
+        "id": 1,
+        "title": "Hoşgeldiniz: Yeni Blogumuza Göz Atın",
+        "content": "<p>Bu bir deneme içeriğidir. Onedio tarzı için basit bir örnek.</p>",
+        "image": "https://via.placeholder.com/800x400",
+    },
+    {
+        "id": 2,
+        "title": "Trendlerde Bugün: En Popüler 10 Haber",
+        "content": "<p>Günün en popüler içeriklerini sizler için derledik.</p>",
+        "image": "https://via.placeholder.com/800x400?text=Trend",
+    },
+]
+
+TRENDING_IDS = [2]
+
+# Basic placeholder AI response for chat
+
 def ai_response(message):
-    # This is a stub; integrate real model here
     return f"AetherAI echo: {message}"
 
-@app.route('/')
+@app.route("/")
 def index():
-    return render_template('index.html')
+    trending = [p for p in POSTS if p["id"] in TRENDING_IDS]
+    return render_template("index.html", posts=POSTS, trending=trending)
+
+@app.route("/post/<int:post_id>")
+def post_detail(post_id):
+    post = next((p for p in POSTS if p["id"] == post_id), None)
+    if not post:
+        abort(404)
+    return render_template("post.html", post=post)
 
 @app.route('/chat', methods=['POST'])
 def chat():

--- a/static/style.css
+++ b/static/style.css
@@ -1,18 +1,45 @@
 body {
     font-family: Arial, sans-serif;
-    max-width: 600px;
-    margin: 2em auto;
-    background-color: #f9f9f9;
+    max-width: 900px;
+    margin: 0 auto;
+    background-color: #f4f4f4;
     padding: 1em;
-    border-radius: 4px;
 }
-#chat-box {
-    border: 1px solid #ccc;
-    padding: 10px;
-    height: 300px;
-    overflow-y: scroll;
+header {
+    text-align: center;
+    padding: 1em 0;
+}
+nav a {
+    margin-right: 10px;
+    text-decoration: none;
+    color: #333;
+}
+.posts {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1em;
+}
+.post-item {
     background: #fff;
+    border-radius: 4px;
+    overflow: hidden;
+    width: calc(50% - 0.5em);
+    box-shadow: 0 0 5px rgba(0,0,0,0.1);
 }
-.user { color: blue; margin: 5px 0; }
-.bot { color: green; margin: 5px 0; }
-.error { color: red; }
+.post-item img {
+    width: 100%;
+    display: block;
+}
+.post-item h3 {
+    padding: 0.5em;
+    font-size: 1.1em;
+}
+.trending h2 {
+    margin-top: 0;
+}
+.post-detail img.detail-img {
+    width: 100%;
+}
+.content {
+    padding: 1em;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="tr">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Blog Demo</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <header>
+        <h1>BlogDemo</h1>
+    </header>
+    <nav>
+        <a href="/">Anasayfa</a>
+    </nav>
+    {% block content %}{% endblock %}
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,35 +1,28 @@
-<!doctype html>
-<html lang="en">
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>AetherAI Chat</title>
-    <link rel="stylesheet" href="/static/style.css">
-</head>
-<body>
-    <h1>AetherAI</h1>
-    <div id="chat-box"></div>
-    <input type="text" id="user-input" placeholder="Type your message" />
-    <button onclick="sendMessage()">Send</button>
-    <script>
-        async function sendMessage() {
-            const inputEl = document.getElementById('user-input');
-            const message = inputEl.value;
-            inputEl.value = '';
-            const res = await fetch('/chat', {
-                method: 'POST',
-                headers: {'Content-Type': 'application/json'},
-                body: JSON.stringify({user: 'demo@example.com', message})
-            });
-            const data = await res.json();
-            const box = document.getElementById('chat-box');
-            if (data.error) {
-                box.innerHTML += '<div class="error">'+data.error+'</div>';
-            } else {
-                box.innerHTML += '<div class="user">'+message+'</div>';
-                box.innerHTML += '<div class="bot">'+data.response+'</div>';
-            }
-        }
-    </script>
-</body>
-</html>
+{% extends 'base.html' %}
+{% block content %}
+<div class="trending">
+    <h2>Trendler</h2>
+    <div class="posts">
+    {% for post in trending %}
+        <div class="post-item">
+            <a href="/post/{{ post.id }}">
+                <img src="{{ post.image }}" alt="{{ post.title }}">
+                <h3>{{ post.title }}</h3>
+            </a>
+        </div>
+    {% endfor %}
+    </div>
+</div>
+
+<h2>Tüm Yazılar</h2>
+<div class="posts">
+{% for post in posts %}
+    <div class="post-item">
+        <a href="/post/{{ post.id }}">
+            <img src="{{ post.image }}" alt="{{ post.title }}">
+            <h3>{{ post.title }}</h3>
+        </a>
+    </div>
+{% endfor %}
+</div>
+{% endblock %}

--- a/templates/post.html
+++ b/templates/post.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+{% block content %}
+<article class="post-detail">
+    <h2>{{ post.title }}</h2>
+    <img src="{{ post.image }}" alt="{{ post.title }}" class="detail-img">
+    <div class="content">{{ post.content|safe }}</div>
+</article>
+{% endblock %}


### PR DESCRIPTION
## Summary
- convert Flask demo into a minimal blog site
- add example posts with trending section
- create page templates for blog layout
- update CSS for blog layout
- document how to run the app

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686452c4c0d48331a2163f7df1a163da