### PR TITLE
Add barcode generator feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,24 @@
 # AetherAI Demo
 
-This repository contains a simple Flask web application demonstrating an AI assistant called **AetherAI**. The application includes a basic chat interface and a placeholder subscription check.
+This repository contains a simple Flask web application demonstrating an AI assistant called **AetherAI**. The application includes a basic chat interface, a barcode generator and a placeholder subscription check.
 
 ## Running the app
 
 1. Install dependencies:
    ```bash
-   pip install flask
+   pip install -r requirements.txt
    ```
 2. Start the server:
    ```bash
    python app.py
-   ```
+  ```
 3. Open `http://localhost:5000` in your browser.
 
+The server's debug mode can be controlled via the `FLASK_DEBUG` environment variable. Set it to `1` to enable debug mode.
+
+### Barcode API
+
+POST `/barcode` with JSON `{ "data": "TEXT" }` or form data `data=TEXT` to receive a PNG barcode image.
+
 A single demo user `demo@example.com` is subscribed by default. Integrate your own subscription and AI logic as needed.
+

--- a/app.py
+++ b/app.py
@@ -1,4 +1,9 @@
-from flask import Flask, render_template, request, jsonify
+import os
+from io import BytesIO
+
+from flask import Flask, render_template, request, jsonify, send_file
+import barcode
+from barcode.writer import ImageWriter
 
 app = Flask(__name__)
 
@@ -24,5 +29,22 @@ def chat():
     response = ai_response(message)
     return jsonify({'response': response})
 
+
+@app.route('/barcode', methods=['POST'])
+def generate_barcode():
+    data = request.form.get('data')
+    if not data:
+        json_data = request.get_json(silent=True)
+        if json_data:
+            data = json_data.get('data')
+    if not data:
+        return jsonify({'error': 'No data provided'}), 400
+    code128 = barcode.get('code128', data, writer=ImageWriter())
+    buffer = BytesIO()
+    code128.write(buffer)
+    buffer.seek(0)
+    return send_file(buffer, mimetype='image/png')
+
 if __name__ == '__main__':
-    app.run(debug=True, host='0.0.0.0')
+    debug_mode = os.getenv('FLASK_DEBUG', '0') in ('1', 'True', 'true')
+    app.run(debug=debug_mode, host='0.0.0.0')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+python-barcode

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,6 +11,12 @@
     <div id="chat-box"></div>
     <input type="text" id="user-input" placeholder="Type your message" />
     <button onclick="sendMessage()">Send</button>
+
+    <hr>
+    <h2>Barcode Generator</h2>
+    <input type="text" id="barcode-data" placeholder="Enter data for barcode" />
+    <button onclick="generateBarcode()">Generate</button>
+    <div><img id="barcode-image" /></div>
     <script>
         async function sendMessage() {
             const inputEl = document.getElementById('user-input');
@@ -28,6 +34,19 @@
             } else {
                 box.innerHTML += '<div class="user">'+message+'</div>';
                 box.innerHTML += '<div class="bot">'+data.response+'</div>';
+            }
+        }
+
+        async function generateBarcode() {
+            const dataEl = document.getElementById('barcode-data');
+            const res = await fetch('/barcode', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({data: dataEl.value})
+            });
+            if(res.ok){
+                const blob = await res.blob();
+                document.getElementById('barcode-image').src = URL.createObjectURL(blob);
             }
         }
     </script>


### PR DESCRIPTION
## Summary
- generate barcodes using python-barcode and expose `/barcode` route
- control debug mode via `FLASK_DEBUG`
- add simple client-side form for barcode generation
- document barcode usage and environment variable
- add dependency list

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6866355325148331b153e959f6a52ee3